### PR TITLE
fix VSCode editor sample config

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -36,7 +36,7 @@ experience.
 {
     "workbench.colorTheme": "GapStyle VS",
     "editor.tokenColorCustomizations": {
-        "semanticHighlighting": true
+        "enabled": true
     }
 }
 ```
@@ -62,7 +62,7 @@ VSCode Editor Config (Full config)
     "editor.fontFamily": "'Hack JBM Ligatured CCG', 'Hack', Menlo, Monaco, 'Courier New', monospace",
     "editor.fontLigatures": true,
     "editor.tokenColorCustomizations": {
-        "semanticHighlighting": true
+        "enabled": true
     }
 }
 ```

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -35,7 +35,7 @@ experience.
 ```
 {
     "workbench.colorTheme": "GapStyle VS",
-    "editor.tokenColorCustomizations": {
+    "editor.semanticTokenColorCustomizations": {
         "enabled": true
     }
 }
@@ -61,7 +61,7 @@ VSCode Editor Config (Full config)
     "workbench.colorTheme": "GapStyle VS",
     "editor.fontFamily": "'Hack JBM Ligatured CCG', 'Hack', Menlo, Monaco, 'Courier New', monospace",
     "editor.fontLigatures": true,
-    "editor.tokenColorCustomizations": {
+    "editor.semanticTokenColorCustomizations": {
         "enabled": true
     }
 }


### PR DESCRIPTION
Suggested by VSCode
Whether semantic highlighting should be enabled for this theme.

Use `enabled` in `editor.semanticTokenColorCustomizations` setting instead.(2)